### PR TITLE
Potential fix for code scanning alert no. 44: Uncontrolled command line

### DIFF
--- a/motioneye/controls/v4l2ctl.py
+++ b/motioneye/controls/v4l2ctl.py
@@ -90,6 +90,11 @@ def list_resolutions(device):
     resolutions = set()
     output = b''
     started = time.time()
+    ALLOWED_DEVICES = ['/dev/video0', '/dev/video1']  # Example allowlist
+    if device not in ALLOWED_DEVICES:
+        logging.error(f'Invalid device "{device}" provided')
+        raise ValueError(f'Invalid device "{device}"')
+
     cmd = f"v4l2-ctl -d {quote(device)} --list-formats-ext | grep -vi stepwise | grep -oE '[0-9]+x[0-9]+' || true"
     logging.debug(f'running command "{cmd}"')
 

--- a/motioneye/utils/__init__.py
+++ b/motioneye/utils/__init__.py
@@ -655,6 +655,11 @@ def call_subprocess(
     env=None,
 ) -> str:
     """subprocess.run wrapper to return output as a decoded string"""
+    ALLOWED_COMMANDS = ['v4l2-ctl', 'which']  # Example allowlist
+    if not isinstance(args, list) or args[0] not in ALLOWED_COMMANDS:
+        logging.error(f'Invalid command "{args}" provided')
+        raise ValueError(f'Invalid command "{args}"')
+
     return subprocess.run(
         args,
         stdin=stdin,


### PR DESCRIPTION
Potential fix for [https://github.com/octodevark/motioneye/security/code-scanning/44](https://github.com/octodevark/motioneye/security/code-scanning/44)

To fix the issue, we need to ensure that user-provided input is sanitized or validated before being passed to `subprocess.run`. The best approach is to implement an allowlist of acceptable commands or arguments and reject any input that does not match the allowlist. Additionally, we should avoid using `shell=True` wherever possible, as it significantly increases the risk of command injection.

**Steps to fix:**
1. Introduce an allowlist of valid commands or arguments in `motioneye/controls/v4l2ctl.py` for the `list_resolutions` function.
2. Validate the `device` parameter against this allowlist before constructing the `cmd` string.
3. Modify `call_subprocess` in `motioneye/utils/__init__.py` to reject unsafe inputs or enforce stricter validation.
4. Ensure that all paths leading to `call_subprocess` sanitize or validate user input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
